### PR TITLE
Adapt to operator rs changes and kube 0.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
 dependencies = [
  "getrandom 0.2.3",
  "instant",
- "rand 0.8.3",
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byteorder"
@@ -219,9 +219,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -620,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "headers"
@@ -651,9 +651,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -694,9 +694,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.8"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f71a7eea53a3f8257a7b4795373ff886397178cd634430ea94e12d7fe4fe34"
+checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -708,7 +708,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.7",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -777,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -960,9 +960,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.95"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "linked-hash-map"
@@ -1028,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -1124,9 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1136,9 +1136,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1156,9 +1156,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
@@ -1169,12 +1169,11 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809348965973b261c3e504c8d0434e465274f78c880e10039914f2c5dcf49461"
+checksum = "6dea6388d3d5498ec651701f14edbaf463c924b5d8829fb2848ccf0bcc7b3c69"
 dependencies = [
  "num-traits",
- "rand 0.8.3",
 ]
 
 [[package]]
@@ -1245,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1333,14 +1332,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
- "rand_chacha 0.3.0",
- "rand_core 0.6.2",
- "rand_hc 0.3.0",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+ "rand_hc 0.3.1",
 ]
 
 [[package]]
@@ -1355,12 +1354,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1374,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.3",
 ]
@@ -1392,18 +1391,18 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.6.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
@@ -1431,11 +1430,10 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
@@ -1589,9 +1587,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1602,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1735,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
@@ -1796,7 +1794,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 [[package]]
 name = "stackable-operator"
 version = "0.1.0-nightly"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=adapt_to_product_config_interface#8addde4adaecfd52ec0878bf2fa39dc6a7076727"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#711135ffdd021eabd21b4b4adbddf9b9ca5f73ea"
 dependencies = [
  "async-trait",
  "backoff",
@@ -1898,9 +1896,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
+checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1926,7 +1924,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -1998,9 +1996,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c2eb13b3ab38208130eccd41be92520388791207fde783bda7c1e8ace28d4"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2027,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2059,9 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2098,9 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
+checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2207,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
 dependencies = [
  "ansi_term 0.12.1",
  "chrono",
@@ -2255,7 +2253,7 @@ dependencies = [
  "httparse",
  "input_buffer",
  "log",
- "rand 0.8.3",
+ "rand 0.8.4",
  "sha-1",
  "url",
  "utf-8",
@@ -2302,9 +2300,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -2356,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.13"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
 
 [[package]]
-name = "array_tool"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f8cb5d814eb646a863c4f24978cff2880c4be96ad8cde2c0f0678732902e271"
-
-[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +68,17 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "getrandom 0.2.3",
+ "instant",
+ "rand 0.8.3",
+]
 
 [[package]]
 name = "base64"
@@ -350,17 +355,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
+name = "encoding"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
 dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
 ]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "filetime"
@@ -637,15 +693,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
 name = "hyper"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,10 +795,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "java-properties"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d179c3692142e6fc4080d48d5a4d9c04738a3bece41ff2abdde13d505590c1b7"
+dependencies = [
+ "encoding",
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "js-sys"
@@ -775,12 +842,10 @@ dependencies = [
 
 [[package]]
 name = "jsonpath_lib"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61352ec23883402b7d30b3313c16cbabefb8907361c4eb669d990cbb87ceee5a"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
 dependencies = [
- "array_tool",
- "env_logger",
  "log",
  "serde",
  "serde_json",
@@ -788,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc1f973542059e6d5a6d63de6a9539d0ec784f82b2327f3c1915d33200bc6a4"
+checksum = "fbff78f6da26dde0d74188966d23fc763431d730d0f766ecf7699209f8fc243c"
 dependencies = [
  "base64",
  "bytes",
@@ -802,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b2fbe85ad92f8435a0f52072f55bd7f0843e082c8e461e56d1ce29440554c8"
+checksum = "8152fba26129a09bf30179092753b399760a305a218b8bc558f9a2087b5c1d70"
 dependencies = [
  "base64",
  "bytes",
@@ -813,36 +878,53 @@ dependencies = [
  "either",
  "futures",
  "http",
+ "http-body",
  "hyper",
  "hyper-rustls",
  "hyper-timeout",
  "hyper-tls",
- "json-patch",
  "jsonpath_lib",
  "k8s-openapi",
- "log",
+ "kube-core",
+ "kube-derive",
  "openssl",
  "pem",
  "pin-project 1.0.7",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
- "static_assertions",
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tracing",
- "url",
+ "webpki",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b767df01404bb99fb75ac2ceded28ce34c30fdcffbb4346e2c44d30756bfba"
+dependencies = [
+ "form_urlencoded",
+ "http",
+ "json-patch",
+ "k8s-openapi",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca5161aebec14aa62448469b4c128d165e70da503d43813702a23deeff9612"
+checksum = "b6d0e5489859d9430689f64e69cacc9bf8cb68556f436c73a6a308d4e256b7a0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -853,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbf7b51e6a4984e929dab0bd13b61592b750a3385e298aaa9100c4830205a12"
+checksum = "f8358421de932e06d0521700fc8ecfc7058c95509e0770d2da88be78cd737c07"
 dependencies = [
  "dashmap",
  "derivative",
@@ -1207,6 +1289,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "product-config"
+version = "0.1.0-nightly"
+source = "git+https://github.com/stackabletech/product-config.git?branch=main#32a81b9adf744c4c02ac4f123f9a4b7bddc94bfc"
+dependencies = [
+ "java-properties",
+ "regex",
+ "schemars",
+ "semver 1.0.3",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,7 +1488,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver",
+ "semver 0.11.0",
 ]
 
 [[package]]
@@ -1417,6 +1514,15 @@ dependencies = [
  "rustls",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1512,6 +1618,12 @@ checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
@@ -1683,10 +1795,11 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stackable-operator"
-version = "0.1.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=main#115b445b1f0a1a25614f16ea2c5e8b413fab3635"
+version = "0.1.0-nightly"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=adapt_to_product_config_interface#8addde4adaecfd52ec0878bf2fa39dc6a7076727"
 dependencies = [
  "async-trait",
+ "backoff",
  "chrono",
  "const_format",
  "either",
@@ -1696,6 +1809,7 @@ dependencies = [
  "kube",
  "kube-runtime",
  "lazy_static",
+ "product-config",
  "regex",
  "schemars",
  "serde",
@@ -1715,11 +1829,11 @@ version = "0.1.0-nightly"
 dependencies = [
  "k8s-openapi",
  "kube",
- "kube-derive",
  "kube-runtime",
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "stackable-operator",
 ]
 
@@ -1771,12 +1885,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,15 +1930,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2008,6 +2107,23 @@ dependencies = [
  "pin-project 1.0.7",
  "tokio",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b56efe69aa0ad2b5da6b942e57ea9f6fe683b7a314d4ff48662e2c8838de1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project 1.0.7",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2396,15 +2512,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,11 +1827,9 @@ version = "0.1.0-nightly"
 dependencies = [
  "k8s-openapi",
  "kube",
- "kube-runtime",
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
  "stackable-operator",
 ]
 

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -11,11 +11,9 @@ stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git",
 
 k8s-openapi = { version = "0.12", default-features = false }
 kube = { version = "0.57", default-features = false, features = ["jsonpatch", "derive"] }
-kube-runtime = "0.57"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.8"
 
 [dev-dependencies]
 k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -7,18 +7,18 @@ name = "stackable-regorule-crd"
 version = "0.1.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "adapt_to_product_config_interface" }
 
-k8s-openapi = { version = "0.11", default-features = false }
-kube = { version = "0.52", default-features = false }
-kube-derive = { version = "0.52", default-features = false, features = ["schema"] }
-kube-runtime = { version = "0.52", default-features = false }
+k8s-openapi = { version = "0.12", default-features = false }
+kube = { version = "0.57", default-features = false, features = ["jsonpatch", "derive"] }
+kube-runtime = "0.57"
 schemars = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8"
 
 [dev-dependencies]
-k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
+k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
 
 [features]
 default = ["native-tls"]

--- a/crd/Cargo.toml
+++ b/crd/Cargo.toml
@@ -7,7 +7,7 @@ name = "stackable-regorule-crd"
 version = "0.1.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "adapt_to_product_config_interface" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 
 k8s-openapi = { version = "0.12", default-features = false }
 kube = { version = "0.57", default-features = false, features = ["jsonpatch", "derive"] }

--- a/crd/src/bin/generate_crd.rs
+++ b/crd/src/bin/generate_crd.rs
@@ -1,0 +1,16 @@
+use kube::CustomResourceExt;
+use stackable_regorule_crd::RegoRule;
+use std::fs;
+
+fn main() {
+    let target_file = "deploy/crd/regorule.crd.yaml";
+    let schema = RegoRule::crd();
+    let string_schema = match serde_yaml::to_string(&schema) {
+        Ok(schema) => schema,
+        Err(err) => panic!("Failed to retrieve CRD: [{}]", err),
+    };
+    match fs::write(target_file, string_schema) {
+        Ok(()) => println!("Successfully wrote CRD to file."),
+        Err(err) => println!("Failed to write file: [{}]", err),
+    }
+}

--- a/crd/src/bin/generate_crd.rs
+++ b/crd/src/bin/generate_crd.rs
@@ -1,16 +1,8 @@
-use kube::CustomResourceExt;
+use stackable_operator::crd::CustomResourceExt;
 use stackable_regorule_crd::RegoRule;
-use std::fs;
 
 fn main() {
     let target_file = "deploy/crd/regorule.crd.yaml";
-    let schema = RegoRule::crd();
-    let string_schema = match serde_yaml::to_string(&schema) {
-        Ok(schema) => schema,
-        Err(err) => panic!("Failed to retrieve CRD: [{}]", err),
-    };
-    match fs::write(target_file, string_schema) {
-        Ok(()) => println!("Successfully wrote CRD to file."),
-        Err(err) => println!("Failed to write file: [{}]", err),
-    }
+    RegoRule::write_yaml_schema(target_file).unwrap();
+    println!("Wrote CRD to [{}]", target_file);
 }

--- a/crd/src/bin/generate_crd.rs
+++ b/crd/src/bin/generate_crd.rs
@@ -3,6 +3,8 @@ use stackable_regorule_crd::RegoRule;
 
 fn main() {
     let target_file = "deploy/crd/regorule.crd.yaml";
-    RegoRule::write_yaml_schema(target_file).unwrap();
-    println!("Wrote CRD to [{}]", target_file);
+    match RegoRule::write_yaml_schema(target_file) {
+        Ok(_) => println!("Wrote CRD to [{}]", target_file),
+        Err(err) => println!("Could not write CRD to [{}]: {:?}", target_file, err),
+    }
 }

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -15,6 +15,7 @@ use stackable_operator::Crd;
     version = "v1",
     kind = "RegoRule",
     shortname = "rego",
+    plural = "regorules",
     namespaced
 )]
 pub struct RegoRuleSpec {
@@ -22,6 +23,6 @@ pub struct RegoRuleSpec {
 }
 
 impl Crd for RegoRule {
-    const RESOURCE_NAME: &'static str = "regorule.opa.stackable.tech";
+    const RESOURCE_NAME: &'static str = "regorules.opa.stackable.tech";
     const CRD_DEFINITION: &'static str = include_str!("../../deploy/crd/regorule.crd.yaml");
 }

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,4 +1,4 @@
-use kube_derive::CustomResource;
+use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use stackable_operator::Crd;

--- a/crd/src/lib.rs
+++ b/crd/src/lib.rs
@@ -1,7 +1,6 @@
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use stackable_operator::Crd;
 
 /// The spec for a RegoRule only has a single field: `rego`.
 ///
@@ -12,7 +11,7 @@ use stackable_operator::Crd;
 )]
 #[kube(
     group = "opa.stackable.tech",
-    version = "v1",
+    version = "v1alpha1",
     kind = "RegoRule",
     shortname = "rego",
     plural = "regorules",
@@ -20,9 +19,4 @@ use stackable_operator::Crd;
 )]
 pub struct RegoRuleSpec {
     pub rego: String,
-}
-
-impl Crd for RegoRule {
-    const RESOURCE_NAME: &'static str = "regorules.opa.stackable.tech";
-    const CRD_DEFINITION: &'static str = include_str!("../../deploy/crd/regorule.crd.yaml");
 }

--- a/deploy/crd/regorule.crd.yaml
+++ b/deploy/crd/regorule.crd.yaml
@@ -13,7 +13,7 @@ spec:
     singular: regorule
   scope: Namespaced
   versions:
-    - name: v1
+    - name: v1alpha1
       schema:
         openAPIV3Schema:
           description: "Auto-generated derived type for RegoRuleSpec via `CustomResource`"

--- a/deploy/crd/regorule.crd.yaml
+++ b/deploy/crd/regorule.crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -12,13 +13,13 @@ spec:
     singular: regorule
   scope: Namespaced
   versions:
-    - additionalPrinterColumns: []
-      name: v1
+    - name: v1
       schema:
         openAPIV3Schema:
           description: "Auto-generated derived type for RegoRuleSpec via `CustomResource`"
           properties:
             spec:
+              description: "The spec for a RegoRule only has a single field: `rego`.\n\nThe string provided should be a complete and valid Rego rule. This means it also needs to specify a package name."
               properties:
                 rego:
                   type: string

--- a/examples/simple-regorule-is-minute-even.yaml
+++ b/examples/simple-regorule-is-minute-even.yaml
@@ -1,4 +1,4 @@
-apiVersion: opa.stackable.tech/v1
+apiVersion: opa.stackable.tech/v1alpha1
 kind: RegoRule
 metadata:
   name: simple

--- a/examples/simple-regorule.yaml
+++ b/examples/simple-regorule.yaml
@@ -1,4 +1,4 @@
-apiVersion: opa.stackable.tech/v1
+apiVersion: opa.stackable.tech/v1alpha1
 kind: RegoRule
 metadata:
   name: simple

--- a/examples/simple-regorule2.yaml
+++ b/examples/simple-regorule2.yaml
@@ -1,4 +1,4 @@
-apiVersion: opa.stackable.tech/v1
+apiVersion: opa.stackable.tech/v1alpha1
 kind: RegoRule
 metadata:
   name: pi

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 
 [dependencies]
 stackable-regorule-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "adapt_to_product_config_interface" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 
 async-trait = "0.1"
 flate2 = "1.0"

--- a/operator/Cargo.toml
+++ b/operator/Cargo.toml
@@ -8,14 +8,14 @@ version = "0.1.0"
 
 [dependencies]
 stackable-regorule-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "adapt_to_product_config_interface" }
 
 async-trait = "0.1"
 flate2 = "1.0"
 futures = "0.3"
-k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"] }
-kube = { version = "0.52", default-features = false }
-kube-runtime = "0.52"
+k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
+kube = { version = "0.57", default-features = false }
+kube-runtime = "0.57"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4"

--- a/operator/src/error.rs
+++ b/operator/src/error.rs
@@ -5,4 +5,7 @@ pub enum Error {
         #[from]
         source: std::io::Error,
     },
+
+    #[error("Object [{obj}] needs to be namespaced!")]
+    NamespaceError { obj: String },
 }

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -36,7 +36,11 @@ fn rebuild_bundle(reader: &Store<RegoRule>) -> Result<(), error::Error> {
     // TODO: Need to make sure that all Kubernetes names are also valid file names
     for rule in reader.state() {
         let name = format!("{}.rego", rule.name());
-        let namespace = rule.namespace().expect("Needs to be namespaced");
+        let namespace = match rule.namespace() {
+            Some(ns) => ns,
+            None => return Err(error::Error::NamespaceError { obj: rule.name() }),
+        };
+
         let path = Path::new(&namespace).join(name);
 
         let data = rule.spec.rego.as_bytes();

--- a/operator/src/lib.rs
+++ b/operator/src/lib.rs
@@ -3,8 +3,9 @@ mod error;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use futures::StreamExt;
-use kube::api::{ListParams, Resource};
+use kube::api::ListParams;
 use kube::Api;
+use kube::ResourceExt;
 use kube_runtime::reflector::store::Writer;
 use kube_runtime::reflector::Store;
 use kube_runtime::{reflector, utils};
@@ -34,8 +35,8 @@ fn rebuild_bundle(reader: &Store<RegoRule>) -> Result<(), error::Error> {
     // The name of the file will be the name of the object with ".rego" appended.
     // TODO: Need to make sure that all Kubernetes names are also valid file names
     for rule in reader.state() {
-        let name = format!("{}.rego", Resource::name(&rule));
-        let namespace = Resource::namespace(&rule).expect("Needs to be namespaced");
+        let name = format!("{}.rego", rule.name());
+        let namespace = rule.namespace().expect("Needs to be namespaced");
         let path = Path::new(&namespace).join(name);
 
         let data = rule.spec.rego.as_bytes();
@@ -71,7 +72,7 @@ pub async fn create_controller(
         // Convert from Result<> to Option<>, discarding any Err values
         .filter_map(|x| async move { std::result::Result::ok(x) })
         .for_each(move |resource| {
-            trace!("Touched {:?}", Resource::name(&resource));
+            trace!("Touched {:?}", resource.name());
             // TODO: Later allow to configure what should happen in case of a failure
             rebuild_bundle(&reader).expect("Building the bundle failed, panicing!");
             futures::future::ready(())

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "OSL-3.0"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "adapt_to_product_config_interface" }
 stackable-regorule-crd = { path = "../crd" }
 stackable-regorule-operator = { path = "../operator" }
 stackable_config = { git = "https://github.com/stackabletech/common.git", branch = "main" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "OSL-3.0"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "adapt_to_product_config_interface" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 stackable-regorule-crd = { path = "../crd" }
 stackable-regorule-operator = { path = "../operator" }
 stackable_config = { git = "https://github.com/stackabletech/common.git", branch = "main" }

--- a/server/src/bin/generate_regorule_crd.rs
+++ b/server/src/bin/generate_regorule_crd.rs
@@ -1,7 +1,0 @@
-use stackable_regorule_crd::RegoRule;
-use std::error::Error;
-
-fn main() -> Result<(), Box<dyn Error>> {
-    println!("{}", serde_yaml::to_string(&RegoRule::crd())?);
-    Ok(())
-}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,7 +2,7 @@ mod config;
 
 use crate::config::RegoRuleConfig;
 use stackable_config::ConfigBuilder;
-use stackable_operator::crd::Crd;
+use stackable_operator::crd::CustomResourceExt;
 use stackable_operator::{client, error};
 use stackable_regorule_crd::RegoRule;
 use std::env;
@@ -21,12 +21,9 @@ async fn main() -> Result<(), error::Error> {
 
     let client = client::create_client(None).await?;
 
-    if let Err(error) = stackable_operator::crd::wait_until_crds_present(
-        &client,
-        vec![RegoRule::RESOURCE_NAME],
-        None,
-    )
-    .await
+    if let Err(error) =
+        stackable_operator::crd::wait_until_crds_present(&client, vec![&RegoRule::crd_name()], None)
+            .await
     {
         error!("Required CRDs missing, aborting: {:?}", error);
     };

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,10 +2,12 @@ mod config;
 
 use crate::config::RegoRuleConfig;
 use stackable_config::ConfigBuilder;
+use stackable_operator::crd::Crd;
 use stackable_operator::{client, error};
+use stackable_regorule_crd::RegoRule;
 use std::env;
 use std::ffi::OsString;
-use tracing::info;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> Result<(), error::Error> {
@@ -16,7 +18,19 @@ async fn main() -> Result<(), error::Error> {
             .expect("Error initializing Configuration!");
 
     info!("Starting Stackable Operator for OpenPolicyAgent Rego rules");
+
     let client = client::create_client(None).await?;
+
+    if let Err(error) = stackable_operator::crd::wait_until_crds_present(
+        &client,
+        vec![RegoRule::RESOURCE_NAME],
+        None,
+    )
+    .await
+    {
+        error!("Required CRDs missing, aborting: {:?}", error);
+    };
+
     let watch_namespace = stackable_operator::namespace::get_watch_namespace()?;
     stackable_regorule_operator::run_reflector_and_server(client, watch_namespace, config.port)
         .await;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<(), error::Error> {
             .await
     {
         error!("Required CRDs missing, aborting: {:?}", error);
+        return Err(error);
     };
 
     let watch_namespace = stackable_operator::namespace::get_watch_namespace()?;


### PR DESCRIPTION
This PR contains multiple changes:

- Adapt to latest operator-rs and kube 0.57
- Add graceful wait if CRD is missing
- Changed version "v1" to "v1alpha1"