### PR TITLE
Move directory for bundle.tar to /tmp/ to avoid permission problems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [0.2.0] - 2021-10-28
+### Changed
+- `operator-rs` `0.3.0` → `0.4.0` ([#96]).
+- `bundle.tar.gz` now written to `tmp` to avoid permission problems in container ([#96]).
 
+### Fixed
+- `Reporule` artifacts (in custom resource) to `Regorule` ([#96]).
+
+[#96]: https://github.com/stackabletech/regorule-operator/pull/96
+
+## [0.2.0] - 2021-10-28
 
 ### Changed
 - `operator-rs` `0.2.2` → `0.3.0` ([#92]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "async-trait"
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c19c08adecde7d68052bfccf9f8ae663f680380e297f20249cef7943df66f54"
+checksum = "75e877325e5540a3041b519bd7ee27a858691f9f816cf533d652cbb33cbfea45"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7ca26f7b912055aec302c376de4f3e1c749d121fbed91088203848e3dbd978"
+checksum = "bb8e1a36f17c63e263ba0ffa2c0658de315c75decad983d83aaeafeda578cc78"
 dependencies = [
  "base64",
  "bytes",
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56229a53d7ce86e3e31c4aaf18a957b6f68305126ebfb12523312b2c8a43f19c"
+checksum = "a91e572d244436fbc0d0b5a4829d96b9d623e08eb6b5d1e80418c1fab10b162a"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -983,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a9c6f93a170382c384eddf05ba165a96b38ecc63db8814d750db2ee349bd89"
+checksum = "2034f57f3db36978ef366f45f1e263e623d9a6a8fcc6a6b1ef8879a213e1d2c4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -996,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.63.1"
+version = "0.63.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a168bfeebab8913a0fca198c1f30d8d8c5f04d3eee1645aa5619a27a0a656c14"
+checksum = "6018cf8410f9d460be3a3ac35deef63b71c860c368016d7bf6871994343728b4"
 dependencies = [
  "dashmap",
  "derivative",
@@ -1024,9 +1024,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libgit2-sys"
@@ -1224,9 +1224,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.36"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1244,9 +1244,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.67"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69df2d8dfc6ce3aaf44b40dec6f487d5a886516cf6879c49e98e0710f310a058"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
@@ -1368,8 +1368,8 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.2.0-nightly"
-source = "git+https://github.com/stackabletech/product-config.git?branch=main#97734dfa78c5e96922b2fc99bbd0cf2a1b7ac89d"
+version = "0.2.0"
+source = "git+https://github.com/stackabletech/product-config.git?tag=0.2.0#e32e33d9094e09b1af29045e05a4ab17c511cedb"
 dependencies = [
  "java-properties",
  "regex",
@@ -1740,9 +1740,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1858,8 +1858,8 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "stackable-operator"
-version = "0.3.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.3.0#a0a1d10260f7921d436a0cd7ba6ce957368e42fb"
+version = "0.4.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.4.0#50c3ee9564b1d3eb9d6e43c5e87c2102afbacc27"
 dependencies = [
  "async-trait",
  "backoff",
@@ -2065,9 +2065,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2094,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2126,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2150,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-regorule-crd"
-version = "0.2.0"
+version = "0.3.0-nightly"
 dependencies = [
  "serde",
  "serde_json",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-regorule-operator"
-version = "0.2.0"
+version = "0.3.0-nightly"
 dependencies = [
  "async-trait",
  "flate2",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-regorule-operator-binary"
-version = "0.2.0"
+version = "0.3.0-nightly"
 dependencies = [
  "anyhow",
  "built",

--- a/README.adoc
+++ b/README.adoc
@@ -14,7 +14,7 @@ NOTE: Currently, the bundle file will be created on disk in the current working 
 == Building
 
 This operator is written in Rust.
-It is developed against the latest Rust release (1.51 at the time of writing this), earlier versions might work but are untested.
+It is developed against the latest Rust release (1.56 at the time of writing this), earlier versions might work but are untested.
 
     cargo build --release
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -1,16 +1,83 @@
 = Usage
 
-The cluster is configured via a YAML file.
+The operator should be deployed in a pod and requires service accounts, and cluster roles to access the CRD and custom resources:
+```
+    ---
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: regorule-operator
+      namespace: default
 
-[source,yaml]
-----
-apiVersion: opa.stackable.tech/v1
-kind: RegoRule
-metadata:
-  name: simple
-spec:
-  rego: |
-    package foobar
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: regorule-operator
+    rules:
+    - apiGroups:
+      - opa.stackable.tech
+      resources:
+      - regorules
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - apiextensions.k8s.io
+      resources:
+      - customresourcedefinitions
+      verbs:
+      - get
+      - list
+      - watch
 
-    simple := foo
-----
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: regorule-operator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: regorule-operator
+    subjects:
+    - kind: ServiceAccount
+      name: regorule-operator
+      namespace: default
+
+    ---
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: regorule-simple-server-single
+      labels:
+        app.kubernetes.io/name: regorule
+        app.kubernetes.io/instance: simple
+    spec:
+      containers:
+        - name: regorule
+          image: docker.stackable.tech/stackable/regorule-operator:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+          - containerPort: 3030
+            hostPort: 3030
+            name: client
+            protocol: TCP
+      serviceAccountName: regorule-operator
+      hostNetwork: true
+
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: regorule-service
+    spec:
+      selector:
+        app.kubernetes.io/name: regorule
+        app.kubernetes.io/instance: simple
+      ports:
+        - protocol: TCP
+          port: 3030
+          targetPort: 3030
+```

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -1,83 +1,100 @@
 = Usage
 
-The operator should be deployed in a pod and requires service accounts, and cluster roles to access the CRD and custom resources:
-```
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: regorule-operator
-      namespace: default
+The cluster is configured via a YAML file.
 
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: regorule-operator
-    rules:
-    - apiGroups:
-      - opa.stackable.tech
-      resources:
-      - regorules
-      verbs:
-      - get
-      - list
-      - watch
-    - apiGroups:
-      - apiextensions.k8s.io
-      resources:
-      - customresourcedefinitions
-      verbs:
-      - get
-      - list
-      - watch
+[source,yaml]
+----
+apiVersion: opa.stackable.tech/v1
+kind: RegoRule
+metadata:
+  name: simple
+spec:
+  rego: |
+    package foobar
 
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: regorule-operator
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: regorule-operator
-    subjects:
-    - kind: ServiceAccount
-      name: regorule-operator
-      namespace: default
+    simple := foo
+----
 
-    ---
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: regorule-simple-server-single
-      labels:
-        app.kubernetes.io/name: regorule
-        app.kubernetes.io/instance: simple
-    spec:
-      containers:
-        - name: regorule
-          image: docker.stackable.tech/stackable/regorule-operator:latest
-          imagePullPolicy: IfNotPresent
-          ports:
-          - containerPort: 3030
-            hostPort: 3030
-            name: client
-            protocol: TCP
-      serviceAccountName: regorule-operator
-      hostNetwork: true
+The operator can be deployed in a pod and requires service accounts and cluster roles to access the CRD and custom resources (this will be available as a Helm chart soon):
 
-    ---
-    apiVersion: v1
-    kind: Service
-    metadata:
-      name: regorule-service
-    spec:
-      selector:
-        app.kubernetes.io/name: regorule
-        app.kubernetes.io/instance: simple
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: regorule-operator
+  namespace: default
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: regorule-operator
+rules:
+- apiGroups:
+  - opa.stackable.tech
+  resources:
+  - regorules
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: regorule-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: regorule-operator
+subjects:
+- kind: ServiceAccount
+  name: regorule-operator
+  namespace: default
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: regorule-simple-server-single
+  labels:
+    app.kubernetes.io/name: regorule
+    app.kubernetes.io/instance: simple
+spec:
+  containers:
+    - name: regorule
+      image: docker.stackable.tech/stackable/regorule-operator:latest
+      imagePullPolicy: IfNotPresent
       ports:
-        - protocol: TCP
-          port: 3030
-          targetPort: 3030
-```
+      - containerPort: 3030
+        hostPort: 3030
+        name: client
+        protocol: TCP
+  serviceAccountName: regorule-operator
+  hostNetwork: true
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: regorule-service
+spec:
+  selector:
+    app.kubernetes.io/name: regorule
+    app.kubernetes.io/instance: simple
+  ports:
+    - protocol: TCP
+      port: 3030
+      targetPort: 3030
+

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "OSL-3.0"
 name = "stackable-regorule-crd"
 repository = "https://github.com/stackabletech/regorule-operator"
-version = "0.2.0"
+version = "0.3.0-nightly"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/stackabletech/regorule-operator"
 version = "0.3.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "OSL-3.0"
 name = "stackable-regorule-operator-binary"
 repository = "https://github.com/stackabletech/regorule-operator"
-version = "0.2.0"
+version = "0.3.0-nightly"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/stackabletech/regorule-operator"
 version = "0.3.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 stackable-regorule-crd = { path = "../crd" }
 stackable-regorule-operator = { path = "../operator" }
 
@@ -22,7 +22,7 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 stackable-regorule-crd = { path = "../crd" }
 
 [package.metadata.deb]

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.3.0-nightly"
 
 [dependencies]
 stackable-regorule-crd = { path = "../crd" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.3.0" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.4.0" }
 
 async-trait = "0.1"
 flate2 = "1.0"

--- a/rust/operator/Cargo.toml
+++ b/rust/operator/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 license = "OSL-3.0"
 name = "stackable-regorule-operator"
 repository = "https://github.com/stackabletech/regorule-operator"
-version = "0.2.0"
+version = "0.3.0-nightly"
 
 [dependencies]
 stackable-regorule-crd = { path = "../crd" }

--- a/rust/operator/src/lib.rs
+++ b/rust/operator/src/lib.rs
@@ -28,7 +28,7 @@ fn rebuild_bundle(reader: &Store<RegoRule>) -> Result<(), error::Error> {
         .expect("Clock went backwards")
         .as_secs();
 
-    let tar_gz = File::create("bundle.tar.gz")?;
+    let tar_gz = File::create("/tmp/bundle.tar.gz")?;
     let gz_encoder = GzEncoder::new(tar_gz, Compression::best());
     let mut tar_builder = Builder::new(gz_encoder);
 
@@ -91,8 +91,8 @@ pub async fn create_server(port: u16) -> impl Future<Output = ()> {
     // TODO: Support ETag
     // TODO: Support TLS
     // TODO: Support configuring the listening address
-    let bundle =
-        warp::path!("opa" / "v1" / "opa" / "bundle.tar.gz").and(warp::fs::file("bundle.tar.gz"));
+    let bundle = warp::path!("opa" / "v1" / "opa" / "bundle.tar.gz")
+        .and(warp::fs::file("/tmp/bundle.tar.gz"));
     let bundle = bundle.with(warp::log("bundle"));
     warp::serve(bundle).run(([0, 0, 0, 0], port))
 }


### PR DESCRIPTION
## Description

- fixes https://github.com/stackabletech/regorule-operator/issues/95
- updated dependencies and using operator-rs 0.4.0
- deployable via:
```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: regorule-operator
  namespace: default

---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: regorule-operator
rules:
- apiGroups:
  - opa.stackable.tech
  resources:
  - regorules
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - apiextensions.k8s.io
  resources:
  - customresourcedefinitions
  verbs:
  - get
  - list
  - watch

---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: regorule-operator
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: regorule-operator
subjects:
- kind: ServiceAccount
  name: regorule-operator
  namespace: default

---
apiVersion: v1
kind: Pod
metadata:
  name: regorule-simple-server-single
  labels:
    app.kubernetes.io/name: regorule
    app.kubernetes.io/instance: simple
spec:
  containers:
    - name: regorule
      image: docker.stackable.tech/stackable/regorule-operator:latest
      imagePullPolicy: IfNotPresent
      ports:
      - containerPort: 3030
        hostPort: 3030
        name: client
        protocol: TCP
  serviceAccountName: regorule-operator
  hostNetwork: true

---
apiVersion: v1
kind: Service
metadata:
  name: regorule-service
spec:
  selector:
    app.kubernetes.io/name: regorule
    app.kubernetes.io/instance: simple
  ports:
    - protocol: TCP
      port: 3030
      targetPort: 3030

```

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
