### PR TITLE
[Merged by Bors] - Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2022-02-09
+
 ### Changed
 
 - `operator-rs` `0.8.0` → `0.10.0` ([#193], [#206]).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-regorule-crd"
-version = "0.6.0-nightly"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-regorule-operator"
-version = "0.6.0-nightly"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "built",

--- a/deploy/helm/regorule-operator/Chart.yaml
+++ b/deploy/helm/regorule-operator/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: regorule-operator
-version: 0.6.0-nightly
-appVersion: "0.6.0-nightly"
+version: 0.6.0
+appVersion: "0.6.0"
 description: The Stackable Operator for RegoRule
 home: https://github.com/stackabletech/regorule-operator
 maintainers:

--- a/deploy/manifests/configmap.yaml
+++ b/deploy/manifests/configmap.yaml
@@ -7,8 +7,8 @@ kind: ConfigMap
 metadata:
   name: regorule-operator-configmap
   labels:
-    helm.sh/chart: regorule-operator-0.6.0-nightly
+    helm.sh/chart: regorule-operator-0.6.0
     app.kubernetes.io/name: regorule-operator
     app.kubernetes.io/instance: regorule-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: regorule-operator-deployment
   labels:
-    helm.sh/chart: regorule-operator-0.6.0-nightly
+    helm.sh/chart: regorule-operator-0.6.0
     app.kubernetes.io/name: regorule-operator
     app.kubernetes.io/instance: regorule-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
@@ -31,7 +31,7 @@ spec:
         - name: regorule-operator
           securityContext:
             {}
-          image: "docker.stackable.tech/stackable/regorule-operator:0.6.0-nightly"
+          image: "docker.stackable.tech/stackable/regorule-operator:0.6.0"
           imagePullPolicy: IfNotPresent
           resources:
             {}

--- a/deploy/manifests/serviceaccount.yaml
+++ b/deploy/manifests/serviceaccount.yaml
@@ -5,10 +5,10 @@ kind: ServiceAccount
 metadata:
   name: regorule-operator-serviceaccount
   labels:
-    helm.sh/chart: regorule-operator-0.6.0-nightly
+    helm.sh/chart: regorule-operator-0.6.0
     app.kubernetes.io/name: regorule-operator
     app.kubernetes.io/instance: regorule-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: regorule-operator/templates/serviceaccount.yaml
@@ -18,10 +18,10 @@ kind: ClusterRoleBinding
 metadata:
   name: regorule-operator-clusterrolebinding
   labels:
-    helm.sh/chart: regorule-operator-0.6.0-nightly
+    helm.sh/chart: regorule-operator-0.6.0
     app.kubernetes.io/name: regorule-operator
     app.kubernetes.io/instance: regorule-operator
-    app.kubernetes.io/version: "0.6.0-nightly"
+    app.kubernetes.io/version: "0.6.0"
     app.kubernetes.io/managed-by: Helm
 subjects:
   - kind: ServiceAccount

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "OSL-3.0"
 name = "stackable-regorule-crd"
 repository = "https://github.com/stackabletech/regorule-operator"
-version = "0.6.0-nightly"
+version = "0.6.0"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.10.0" }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "OSL-3.0"
 name = "stackable-regorule-operator"
 repository = "https://github.com/stackabletech/regorule-operator"
-version = "0.6.0-nightly"
+version = "0.6.0"
 
 [dependencies]
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.10.0" }


### PR DESCRIPTION
## Description

* This PR is just one commit so no squashing necessary..
* No bumping to next development version is done here anymore. Followup PR needed after this one is merged.
* Regenerated Helm chart

Manual steps:

```
git sw -c release-0.6.0
# update CHANGELOG
cargo-version.py --release
cargo update --workspace
make regenerate-charts
git commit -am "Release 0.6.0"
git tag -a 0.6.0 -m "Release 0.6.0" HEAD

git push -u origin release-0.6.0
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [x] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
